### PR TITLE
modified SPI connection code to use SPISettings

### DIFF
--- a/src/LIS3DHTR.cpp
+++ b/src/LIS3DHTR.cpp
@@ -43,16 +43,15 @@ void LIS3DHTR<T>::begin(SPIClass &comm, uint8_t sspin)
     _wire_com = NULL;
     pinMode(chipSelectPin, OUTPUT);
     digitalWrite(chipSelectPin, HIGH);
-    // start the SPI library:
-    _spi_com->begin();
-    // Maximum SPI frequency is 10MHz, could divide by 2 here:
-    _spi_com->setClockDivider(SPI_CLOCK_DIV4);
-    // Data is read and written MSb first.
-    _spi_com->setBitOrder(MSBFIRST);
+
+    // Maximum SPI frequency is 10MHz, Data is read and written MSb first,
     // Data is captured on rising edge of clock (CPHA = 0)
     // Base value of the clock is HIGH (CPOL = 1)
     // MODE3 for 328p operation
-    _spi_com->setDataMode(SPI_MODE3);
+    SPISettings _settings(10000000, MSBFIRST, SPI_MODE3);
+
+    // start the SPI library:
+    _spi_com->begin();
 
     delay(200);
 
@@ -377,10 +376,12 @@ void LIS3DHTR<T>::writeRegister(uint8_t reg, uint8_t val)
 {
     if (_spi_com != NULL)
     {
+        _spi_com->beginTransaction(_settings);
         digitalWrite(chipSelectPin, LOW);
         _spi_com->transfer(reg);
         _spi_com->transfer(val);
         digitalWrite(chipSelectPin, HIGH);
+        _spi_com->endTransaction();
     }
     else
     {
@@ -402,6 +403,7 @@ void LIS3DHTR<T>::readRegisterRegion(uint8_t *outputPointer, uint8_t reg, uint8_
 
     if (_spi_com != NULL)
     {
+        _spi_com->beginTransaction(_settings);
         digitalWrite(chipSelectPin, LOW);
         _spi_com->transfer(reg | 0x80 | 0x40); //Ored with "read request" bit and "auto increment" bit
         while (i < length)                     // slave may send less than requested
@@ -412,6 +414,7 @@ void LIS3DHTR<T>::readRegisterRegion(uint8_t *outputPointer, uint8_t reg, uint8_
             i++;
         }
         digitalWrite(chipSelectPin, HIGH);
+        _spi_com->endTransaction();        
     }
     else
     {

--- a/src/LIS3DHTR.h
+++ b/src/LIS3DHTR.h
@@ -238,6 +238,7 @@ private:
     uint8_t commInterface;
     uint8_t chipSelectPin;
     SPIClass *_spi_com;
+    SPISettings _settings;
     TwoWire *_wire_com;
 };
 


### PR DESCRIPTION
According to 
https://www.arduino.cc/en/Reference/SPISetClockDivider
SPI Class documentation, functions 
SetClockDivider
setBitOrder
setDataMode
are being depreciated and should not be used in new projects. The recomended way is to use SPISettings object passed to begin method.
Read more here:
https://www.arduino.cc/en/Tutorial/SPITransaction
https://www.arduino.cc/en/Reference/SPISettings

This fixes compilation problem on Seeeduino XIAO RP2040. 
![image](https://user-images.githubusercontent.com/32562299/142766161-b122b93b-6a65-472a-a86a-8577c62b6c16.png)
